### PR TITLE
[Feature] - Gerar migration para tabela de tasks

### DIFF
--- a/db/migrate/20230427183557_create_tasks.rb
+++ b/db/migrate/20230427183557_create_tasks.rb
@@ -1,0 +1,11 @@
+class CreateTasks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :tasks do |t|
+      t.string :description, null: false
+      t.boolean :done, default: false, null: false
+      t.date :date
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230427190009_add_parents_to_tasks.rb
+++ b/db/migrate/20230427190009_add_parents_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddParentsToTasks < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :tasks, :parent, foreign_key: { to_table: :tasks }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,29 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2023_04_27_190009) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "tasks", force: :cascade do |t|
+    t.string "description", null: false
+    t.boolean "done", default: false, null: false
+    t.date "date"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "parent_id"
+    t.index ["parent_id"], name: "index_tasks_on_parent_id"
+  end
+
+  add_foreign_key "tasks", "tasks", column: "parent_id"
+end


### PR DESCRIPTION
Temos a necessidade de persistir as tasks em nosso banco de dados. Com isso é necessário configurar e criar uma migration de task para cumprir com esse objetivo.

Teremos a princípio 4 campos na tabela:

Description (string)
Done (boolean)
Data (date)
Parent (int - default nil)

Essa model de task terá relacionamento consigo mesmo

Closes #2 