### PR TITLE
[Topic] - Mudar o status da task principal quando todas as subtasks estiverem finalizadas

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,12 +2,6 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:update, :destroy, :change_status]
 
   def index
-    if filter_date_params
-      @tasks = Task.filter_by_date(start_date: start_date, end_date: end_date)
-      @tasks_presenters = @tasks.map { |task| TaskPresenter.new(task: task) }
-      return
-    end
-
     @tasks_today = Task.only_today
     @tasks_tomorrow = Task.only_tomorrow
     @tasks_today_presenters = @tasks_today.map { |task| TaskPresenter.new(task: task) }
@@ -20,11 +14,18 @@ class TasksController < ApplicationController
   def create
     begin
       @task = Task.new(task_params)
+
       @task.transaction do
         @task.save!
-        redirect_to tasks_path, success: "Tarefa criada com sucesso"
+
+        if task_params[:parent_id].nil?
+          @task.reload
+          change_status_parent(parent: @task.parent)
+        end
       end
-    rescue
+
+      redirect_to tasks_path, success: "Tarefa criada com sucesso"
+    rescue => exception
       redirect_to new_task_path, danger: @task.errors.full_messages.to_sentence
     end
   end
@@ -54,8 +55,13 @@ class TasksController < ApplicationController
       old_status = @task.done
 
       @task.update(done: !old_status)
+
+      if @task.sub_task?
+        change_parent_status(parent: @task.parent)
+      end
+
       redirect_to tasks_path
-    rescue
+    rescue => exception
       redirect_to tasks_path, danger: "Ocorreu um erro ao mudar o status da tarefa"
     end
   end
@@ -84,15 +90,7 @@ class TasksController < ApplicationController
     end
   end
 
-  def filter_date_params
-    nil
-  end
-
-  def start_date
-    filter_date_params[:date].beginning_of_day
-  end
-
-  def end_date
-    filter_date_params[:date].end_of_day
+  def change_parent_status(parent:)
+    parent.change_parent_status!
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -18,9 +18,9 @@ class TasksController < ApplicationController
       @task.transaction do
         @task.save!
 
-        if task_params[:parent_id].nil?
+        unless task_params[:parent_id].nil?
           @task.reload
-          change_status_parent(parent: @task.parent)
+          change_parent_status(parent: @task.parent)
         end
       end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -19,7 +19,23 @@ class Task < ApplicationRecord
     .order(date: :asc)
   }
 
+  def sub_task?
+    !self.parent_id.nil?
+  end
+
+  def all_sub_task_done?
+    return if sub_task?
+    self.sub_tasks.all?(&:done?)
+  end
+
   def has_sub_task?
     !self.sub_tasks.empty?
+  end
+
+  def change_parent_status!
+    status = false
+    status = true if self.all_sub_task_done?
+
+    self.update(done: status)
   end
 end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -14,5 +14,28 @@ FactoryBot.define do
         sub_task.save
       end
     end
+
+    trait :with_two_sub_tasks do
+      after(:create) do |task|
+        2.times do
+          sub_task = create(:task)
+          sub_task.parent_id = task.id
+          sub_task.save
+        end
+      end
+    end
+
+    trait :with_at_least_one_completed_subtask do
+      after(:create) do |task|
+        sub_task_one = create(:task)
+        sub_task_one.parent_id = task.id
+        sub_task_one.done = true
+        sub_task_one.save
+
+        sub_task_two = create(:task)
+        sub_task_two.parent_id = task.id
+        sub_task_two.save
+      end
+    end
   end
 end


### PR DESCRIPTION
# Objetivo
Pensando na necessidade de finalizar as tasks principais, quando todas as suas subtasks estiverem finalizadas, se fez necessário criar uma lógica que fizesse tal ação.

Este PR entrega esta solução.

## Exemplo
### Concluída
![image](https://user-images.githubusercontent.com/68401286/235373158-26e7967c-3f72-4b64-864e-08df76d63308.png)

## Chack-list
- [x] Ao finalizar todas as subtarefas, a tarefa pai precisa também ser finalizada

## PRs relacionados
[[Feature] - Adicionando a funcionalidade de marcar/desmarcar uma tarefa como concluída](https://github.com/SantosDiv/todo-list-rails/pull/20)