### PR TITLE
[Fix] - Não permitir que a sub task seja criada com uma data diferente da task original

### DIFF
--- a/app/exceptions/create_task_exception.rb
+++ b/app/exceptions/create_task_exception.rb
@@ -1,0 +1,6 @@
+class CreateTaskException < RuntimeError
+  def initialize(message: nil)
+    message ||= 'Data da subtarefa não pode ser diferente da tarefa original.'
+    super(message)
+  end
+end

--- a/app/use_cases/create_task.rb
+++ b/app/use_cases/create_task.rb
@@ -1,0 +1,41 @@
+class CreateTask
+  def initialize(task_params:)
+    @task_params = task_params
+    validate_params!
+  end
+
+  def execute
+    validate_datetime_subtask! if subtask?
+
+    task = Task.create(@task_params)
+    update_parent_status(parent: task.parent) if subtask?
+    task
+  end
+
+  private
+
+  def validate_params!
+    required_params = [{ key: :description, key_translated: "descrição" }]
+    required_params.each do |required_param|
+      key = required_param[:key]
+      if @task_params[key].nil? || @task_params[key].empty?
+        raise CreateTaskException.new(message: "A #{required_param[:key_translated]} é obrigatório(a)")
+      end
+      true
+    end
+  end
+
+  def subtask?
+    @task_params[:parent_id].present?
+  end
+
+  def update_parent_status(parent:)
+    parent.change_parent_status!
+  end
+
+  def validate_datetime_subtask!
+    parent_task = Task.find(@task_params[:parent_id])
+    raise CreateTaskException.new if parent_task.date.to_date != @task_params[:date].to_date
+    true
+  end
+end

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -8,7 +8,7 @@
   <header class="header-task">
     <div class="d-flex align-items-center">
       <i class="bi bi-list-task fs-4 me-2 mt-1"></i>
-      <% if params[:parent_id] %>
+      <% if @parent_id.present? %>
         <h5 class="m-0 title">Nova sub-tarefa</h5>
       <% else %>
         <h5 class="m-0 title">Nova Tarefa</h5>
@@ -19,7 +19,7 @@
   <hr class="mt-2">
 
   <%= form_with url: tasks_path, local: true do |form| %>
-    <%= form.hidden_field :parent_id, value: params[:parent_id] %>
+    <%= form.hidden_field :parent_id, value: @parent_id %>
     <div class="row">
       <div class="col-auto">
         <%= form.label "Titulo", for: :description, class: "form-label" %>

--- a/spec/use_cases/create_task_spec.rb
+++ b/spec/use_cases/create_task_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+describe CreateTask do
+  describe "#execute" do
+    context "when params is invalid" do
+      let(:invalid_task_params) {
+        {
+          descripion: nil
+        }
+      }
+
+      let(:uc) { described_class }
+
+      it 'raise error CreateTaskException' do
+        expect{ uc.new(task_params: invalid_task_params) }.to raise_error(CreateTaskException)
+      end
+    end
+
+    context "when params is valid" do
+      let(:valid_task_params) {
+        {
+          description: "New Task",
+          date: Time.zone.now
+        }
+      }
+
+      let(:uc) { described_class }
+
+      it 'build class successfully' do
+        expect(uc.new(task_params: valid_task_params)).to be_instance_of(CreateTask)
+      end
+
+      context "and is a parent task" do
+        it 'create the task successfully' do
+          task = uc.new(task_params: valid_task_params).execute
+
+          expect(task.description).to eq(valid_task_params[:description])
+          expect(Task.count).to eq(1)
+        end
+      end
+
+      context 'and is a subtask' do
+        let(:parent_task) { create(:task) }
+
+        let(:params) {
+          {
+            parent_id: parent_task.id,
+            **valid_task_params
+          }
+        }
+
+        it 'create subtask successfully' do
+          task = uc.new(task_params: params).execute
+
+          expect(task.description).to eq(params[:description])
+          expect(task.parent_id).to eq(parent_task.id)
+          expect(Task.count).to eq(2)
+        end
+
+        context 'the date is different from the original task' do
+          let(:parent_task) { create(:task) }
+          let(:params) {
+            {
+              descripion: "My Description",
+              parent_id: parent_task.id,
+              date: parent_task.date + 1.day
+            }
+          }
+
+          it 'raise error CreateTakeException' do
+            expect{ uc.new(task_params: params) }.to raise_error(CreateTaskException)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Objetivo

Pelo fato de uma subtask estar diretamente ligada a uma task, não faz sentido que a mesma tenha uma data diferente de execução. Pois ai entraria em uma inconsistência. Pensando nisso, é necessário que a subtask receba a mesma data da task pai, no momento da sua criação.

## Check-list
- [x] Não permitir que uma subtask seja criada com uma data diferente da sua task pai.

## Issue Actions
#18 Closes