### PR TITLE
[Topic] - Refatorando a lógica de criação e atualização

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -23,7 +23,7 @@ class TasksController < ApplicationController
       uc.execute
 
       redirect_to tasks_path, success: "Tarefa criada com sucesso"
-    rescue CreateTaskException => exception
+    rescue TaskException => exception
       redirect_to get_redirect_path(action: :new), danger: exception.message
     rescue
       redirect_to new_task_path, danger: "Ocorreu um erro inesperado."
@@ -32,13 +32,13 @@ class TasksController < ApplicationController
 
   def update
     begin
-      validate_params!
+      uc = UpdateTask.new(task_params: task_params)
+      uc.execute(task_model: @task)
 
-      @task.update(task_params)
       redirect_to tasks_path, success: "Tarefa atualizada com sucesso"
-    rescue CreateTaskException => exception
+    rescue TaskException => exception
       redirect_to get_redirect_path(action: :edit), danger: exception.message
-    rescue
+    rescue => exception
       redirect_to tasks_path, danger: "Ocorreu um erro inesperado."
     end
   end
@@ -89,17 +89,6 @@ class TasksController < ApplicationController
 
   def parent_id
     params[:parent_id]
-  end
-
-  def validate_params!
-    required_params = [{ key: :description, key_translated: "descrição" }]
-    required_params.each do |required_param|
-      key = required_param[:key]
-      if params[key].nil? || params[key].empty?
-        raise CreateTaskException.new(message: "A #{required_param[:key_translated]} é obrigatório(a)")
-      end
-      true
-    end
   end
 
   def change_parent_status(parent:)

--- a/app/exceptions/create_task_exception.rb
+++ b/app/exceptions/create_task_exception.rb
@@ -1,6 +1,0 @@
-class CreateTaskException < RuntimeError
-  def initialize(message: nil)
-    message ||= 'Data da subtarefa não pode ser diferente da tarefa original.'
-    super(message)
-  end
-end

--- a/app/exceptions/task_exception.rb
+++ b/app/exceptions/task_exception.rb
@@ -1,0 +1,6 @@
+class TaskException < RuntimeError
+  def initialize(message: nil)
+    message ||= 'Ocorreu um erro durante a manipulação da task.'
+    super(message)
+  end
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -23,6 +23,10 @@ class Task < ApplicationRecord
     !self.parent_id.nil?
   end
 
+  def parent?
+    self.parent_id.nil?
+  end
+
   def all_sub_task_done?
     return if sub_task?
     self.sub_tasks.all?(&:done?)

--- a/app/use_cases/create_task.rb
+++ b/app/use_cases/create_task.rb
@@ -1,12 +1,5 @@
-class CreateTask
-  def initialize(task_params:)
-    @task_params = task_params
-    validate_params!
-  end
-
+class CreateTask < TasksManager
   def execute
-    validate_datetime_subtask! if subtask?
-
     task = Task.create(@task_params)
     update_parent_status(parent: task.parent) if subtask?
     task
@@ -14,28 +7,7 @@ class CreateTask
 
   private
 
-  def validate_params!
-    required_params = [{ key: :description, key_translated: "descrição" }]
-    required_params.each do |required_param|
-      key = required_param[:key]
-      if @task_params[key].nil? || @task_params[key].empty?
-        raise CreateTaskException.new(message: "A #{required_param[:key_translated]} é obrigatório(a)")
-      end
-      true
-    end
-  end
-
-  def subtask?
-    @task_params[:parent_id].present?
-  end
-
   def update_parent_status(parent:)
     parent.change_parent_status!
-  end
-
-  def validate_datetime_subtask!
-    parent_task = Task.find(@task_params[:parent_id])
-    raise CreateTaskException.new if parent_task.date.to_date != @task_params[:date].to_date
-    true
   end
 end

--- a/app/use_cases/tasks_manager.rb
+++ b/app/use_cases/tasks_manager.rb
@@ -1,0 +1,40 @@
+class TasksManager
+  def initialize(task_params:)
+    @task_params = task_params
+    validate_params!
+  end
+
+  def execute
+    raise NotImplementedError.new("Method should be implemented in concrete class")
+  end
+
+  private
+
+  def validate_params!
+    required_params = [{ key: :description, key_translated: "descrição" }]
+
+    validate_datetime_subtask! if subtask?
+
+    required_params.each do |required_param|
+      key = required_param[:key]
+      if @task_params[key].nil? || @task_params[key].empty?
+        raise TaskException.new(message: "A #{required_param[:key_translated]} é obrigatório(a)")
+      end
+      true
+    end
+  end
+
+  def subtask?
+    @task_params[:parent_id].present?
+  end
+
+  def validate_datetime_subtask!
+    parent_task = Task.find(@task_params[:parent_id])
+
+    if parent_task.date.to_date != @task_params[:date].to_date
+      raise TaskException.new(message: 'A data da subtarefa não pode ser diferente da tarefa original.')
+    end
+
+    true
+  end
+end

--- a/app/use_cases/update_task.rb
+++ b/app/use_cases/update_task.rb
@@ -1,0 +1,32 @@
+class UpdateTask < TasksManager
+  def execute(task_model:)
+    @old_task_date = task_model.date.to_date
+
+    task_model.update(@task_params)
+
+    update_date_subtasks(parent_task_updated: task_model) if task_model.parent?
+
+    task_model
+  end
+
+  private
+
+  def update_date_subtasks(parent_task_updated:)
+    return unless parent_task_updated.has_sub_task?
+
+    subtasks = parent_task_updated.sub_tasks
+
+    date_parent_task = parent_task_updated.date.to_date
+
+    subtasks.each do |subtask|
+      original_time = subtask.date.strftime("%H:%M")
+
+      subtask.update(date: "#{date_parent_task} #{original_time}")
+    end
+  end
+
+  def date_parent_task_changed?(before_updated:)
+    new_task_date = @task_params[:date].to_date
+    @old_task_date != new_task_date
+  end
+end

--- a/spec/use_cases/create_task_spec.rb
+++ b/spec/use_cases/create_task_spec.rb
@@ -11,8 +11,8 @@ describe CreateTask do
 
       let(:uc) { described_class }
 
-      it 'raise error CreateTaskException' do
-        expect{ uc.new(task_params: invalid_task_params) }.to raise_error(CreateTaskException)
+      it 'raise error TaskException' do
+        expect{ uc.new(task_params: invalid_task_params) }.to raise_error(TaskException)
       end
     end
 
@@ -67,8 +67,8 @@ describe CreateTask do
             }
           }
 
-          it 'raise error CreateTakeException' do
-            expect{ uc.new(task_params: params) }.to raise_error(CreateTaskException)
+          it 'raise error TaskException' do
+            expect{ uc.new(task_params: params) }.to raise_error(TaskException)
           end
         end
       end

--- a/spec/use_cases/create_task_spec.rb
+++ b/spec/use_cases/create_task_spec.rb
@@ -30,7 +30,7 @@ describe CreateTask do
         expect(uc.new(task_params: valid_task_params)).to be_instance_of(CreateTask)
       end
 
-      context "and is a parent task" do
+      context "and it is a parent task" do
         it 'create the task successfully' do
           task = uc.new(task_params: valid_task_params).execute
 
@@ -39,7 +39,7 @@ describe CreateTask do
         end
       end
 
-      context 'and is a subtask' do
+      context 'and it is a subtask' do
         let(:parent_task) { create(:task) }
 
         let(:params) {

--- a/spec/use_cases/update_task_spec.rb
+++ b/spec/use_cases/update_task_spec.rb
@@ -1,0 +1,113 @@
+require 'rails_helper'
+
+describe UpdateTask do
+  describe "#execute" do
+    let(:task) { create(:task) }
+    context "when params is invalid" do
+      let(:invalid_task_params) {
+        {
+          id: task.id,
+          descripion: nil
+        }
+      }
+
+      let(:uc) { described_class }
+
+      it 'raise error TaskException' do
+        expect{ uc.new(task_params: invalid_task_params) }.to raise_error(TaskException)
+      end
+
+      context 'the subtask date is different from the original task' do
+        let(:parent_task) { create(:task, :with_sub_task) }
+
+        let(:subtask) { parent_task.sub_tasks }
+        let(:params) {
+          {
+            id: subtask.first.id,
+            descripion: "My Description",
+            date: parent_task.date + 1.day
+          }
+        }
+
+        it 'raise error TaskException' do
+          expect{ uc.new(task_params: params) }.to raise_error(TaskException)
+        end
+      end
+    end
+
+    context "when params is valid" do
+      let(:valid_task_params) {
+        {
+          id: task.id,
+          description: "New description"
+        }
+      }
+
+      let(:uc) { described_class }
+
+      it 'build class successfully' do
+        expect(uc.new(task_params: valid_task_params)).to be_instance_of(UpdateTask)
+      end
+
+      context "and it is a parent task and has no subtasks" do
+        let(:params) {
+          {
+            date: task.date,
+            **valid_task_params
+          }
+        }
+
+        it 'update the task successfully' do
+          task_updated = uc.new(task_params: params).execute(task_model: task)
+
+          expect(task_updated.description).to eq(valid_task_params[:description])
+        end
+      end
+
+      context "and it is a parent task and has subtasks" do
+        let(:parent_task) { create(:task, :with_sub_task) }
+        let(:subtask) { parent_task.sub_tasks.first }
+
+        let(:params) {
+          {
+            date: Time.zone.now,
+            **valid_task_params
+          }
+        }
+
+        it 'update the task successfully' do
+          task_updated = uc.new(task_params: params).execute(task_model: task)
+
+          expect(task_updated.description).to eq(valid_task_params[:description])
+        end
+
+        context 'changed date of parent task' do
+          it 'update the date of subtask successfully' do
+            task_updated = uc.new(task_params: params).execute(task_model: task)
+
+            expect(subtask.date.to_date).to eq(task_updated.date.to_date)
+          end
+        end
+      end
+
+      context 'and it is a subtask' do
+        let(:parent_task) { create(:task, :with_sub_task) }
+        let(:subtask) { parent_task.sub_tasks.first }
+
+        let(:params) {
+          {
+            id: subtask.id,
+            description: "New description"
+          }
+        }
+
+        it 'update subtask successfully' do
+          subtask_updated = uc.new(task_params: params).execute(task_model: subtask)
+
+          expect(subtask_updated.description).to eq(params[:description])
+          expect(subtask_updated.parent_id).to eq(parent_task.id)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Objetivo
Diante de uma melhor organização do código e melhor divisão de responsabilidades, se fez necessário a refatoração da lógica de criação e atualização de tasks. Retirando da controller a complexidade da lógica de negócio.

Este PR entrega essa solução.

## Check list
- [x] Criar manager de tasks
- [x] Incluir herança do manager no create_task
- [x] Criar uc para update de task, com herança do manager
- [x] Refatorar testes de create
- [x] Criar testes para o uc de update

## PRs relacionados
[[Feature] - Adicionando a funcionalidade de Editar tasks/subtasks](https://github.com/SantosDiv/todo-list-rails/pull/24)

## Issues Actions
