### PR TITLE
[Topic] - Criando um form genérico para as vies de `new` e `edit`

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,10 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:edit, :update, :destroy, :change_status]
 
   def index
-    @tasks_today = Task.only_today
-    @tasks_tomorrow = Task.only_tomorrow
-    @tasks_today_presenters = @tasks_today.map { |task| TaskPresenter.new(task: task) }
-    @tasks_tomorrow_presenters = @tasks_tomorrow.map { |task| TaskPresenter.new(task: task) }
+    @show_tasks_days = get_tasks_by_filter_date || get_standard_day_tasks
   end
 
   def new
@@ -103,6 +100,44 @@ class TasksController < ApplicationController
 
     return new_task_path(parent_id: parent_id) if parent_id.present?
     new_task_path
+  end
+
+  def get_standard_day_tasks
+    [
+      {
+        label_day: "Hoje",
+        tasks_presenters: get_all_tasks_by_date(date: today)
+      },
+      {
+        label_day: "Amanhã",
+        tasks_presenters:  get_all_tasks_by_date(date: tomorrow)
+      }
+    ]
+  end
+
+  def get_tasks_by_filter_date
+    return if params[:filter_date].nil?
+
+    [
+      {
+        label_day: params[:filter_date].to_date.strftime("%d/%m/%Y"),
+        tasks_presenters: get_all_tasks_by_date(date: params[:filter_date])
+      }
+    ]
+  end
+
+  def get_all_tasks_by_date(date:)
+    tasks = Task.filter_by(date: date)
+
+    tasks.map { |task| TaskPresenter.new(task: task) }
+  end
+
+  def today
+    Time.zone.today
+  end
+
+  def tomorrow
+    Time.zone.tomorrow
   end
 
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -7,15 +7,8 @@ class Task < ApplicationRecord
 
   scope :only_parent, -> { where(parent_id: nil) }
 
-  scope :filter_by_date, -> (start_date:, end_date:) { where(date: start_date..end_date, parent_id: nil) }
-
-  scope :only_today, -> {
-    where(date: Time.zone.today.beginning_of_day..Time.zone.today.end_of_day, parent_id: nil)
-    .order(date: :asc)
-  }
-
-  scope :only_tomorrow, -> {
-    where(date: Time.zone.tomorrow.beginning_of_day..Time.zone.tomorrow.end_of_day, parent_id: nil)
+  scope :filter_by, -> (date:) {
+    where(date: date.beginning_of_day..date.end_of_day, parent_id: nil)
     .order(date: :asc)
   }
 

--- a/app/presenter/task_presenter.rb
+++ b/app/presenter/task_presenter.rb
@@ -15,6 +15,10 @@ class TaskPresenter
     @task.parent_id
   end
 
+  def parent?
+    @task.parent?
+  end
+
   def done?
     @task.done
   end
@@ -32,6 +36,14 @@ class TaskPresenter
   def status_class_icon
     return "done-icon" if self.done?
     return "text-secondary"
+  end
+
+  def description_class
+    class_css = ""
+    class_css << "line-through text-secondary" if @task.done?
+
+    return class_css << " fw-light fs-6" if @task.sub_task?
+    class_css << " fw-normal"
   end
 
   def has_sub_task?

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,0 +1,19 @@
+<%= form_with url: path, local: true, method: method do |form| %>
+  <%= form.hidden_field :parent_id, value: @parent_id %>
+
+  <div class="row">
+    <div class="col-auto">
+      <%= form.label "Titulo", for: :description, class: "form-label" %>
+      <%= form.text_field :description, value: @task&.description, placeholder: "Buscar crianças na escola",  class: "form-control", required: true %>
+    </div>
+    <div class="col-auto">
+      <%= form.label "Data da tarefa", for: :date, class: "form-label" %>
+      <%= form.datetime_field :date, value: @time_value, class: "form-control"%>
+    </div>
+  </div>
+  <div class="row mt-3">
+    <div class="col-auto">
+      <%= form.submit "Criar", class: "form-control btn btn-primary"%>
+    </div>
+  </div>
+<% end %>

--- a/app/views/tasks/_task_content.html.erb
+++ b/app/views/tasks/_task_content.html.erb
@@ -1,0 +1,21 @@
+<div class="d-flex justify-content-between align-items-center gap-3 task">
+
+  <%= render partial: "tasks/change_task_status_btn", locals: { task_presenter: task_presenter } %>
+
+  <h5 class="m-0 <%= task_presenter.description_class %>"%>
+    <%= task_presenter.description %>
+  </h5>
+  <span class="<%= task_presenter.status_class_badge %>"><%= task_presenter.status_translated %></span>
+</div>
+<div class="actions d-flex align-items-center gap-4">
+  <% if task_presenter.parent? %>
+    <%= link_to '+ Adicionar subtarefa', new_task_path(parent_id: task_presenter.task_id), class: "btn" %>
+  <% end %>
+  <%= link_to edit_task_path(id: task_presenter.task_id, parent_id: task_presenter.parent_id), class: "text-secondary" do %>
+    <i class="bi bi-pencil-fill fs-6"></i>
+  <% end %>
+  <%= link_to task_path(task_presenter.task_id), method: :delete, class: "text-danger fw-bold",
+      data: { confirm: "Tem certeza que deseja deletar?" } do %>
+    <i class="bi bi-x-lg <%= task_presenter.parent? ? "fs-5" : "fs-6"%>"></i>
+  <% end %>
+</div>

--- a/app/views/tasks/_task_wrapper.html.erb
+++ b/app/views/tasks/_task_wrapper.html.erb
@@ -1,44 +1,13 @@
 <article class="task-wrapper">
   <div class="task-container d-flex justify-content-between align-items-center mb-3">
-    <div class="d-flex justify-content-between align-items-center gap-3 task">
-
-      <%= render partial: "tasks/change_task_status_btn", locals: { task_presenter: task_presenter } %>
-
-      <h5 class="m-0 fw-normal <%= task_presenter.done? ? "line-through" : ""%>"><%= task_presenter.description %></h5>
-      <span class="<%= task_presenter.status_class_badge %>"><%= task_presenter.status_translated %></span>
-    </div>
-    <div class="actions d-flex align-items-center gap-4">
-      <%= link_to '+ Adicionar subtarefa', new_task_path(parent_id: task_presenter.task_id), class: "btn" %>
-      <%= link_to edit_task_path(task_presenter.task_id), class: "text-secondary" do %>
-        <i class="bi bi-pencil-fill fs-6"></i>
-      <% end %>
-      <%= link_to task_path(task_presenter.task_id), method: :delete, class: "text-danger fw-bold",
-          data: { confirm: "Tem certeza que deseja deletar?" } do %>
-        <i class="bi bi-x-lg fs-5"></i>
-      <% end %>
-    </div>
+    <%= render partial: 'tasks/task_content', locals: { task_presenter: task_presenter } %>
   </div>
   <article class="subtasks-container">
   <% if task_presenter.has_sub_task? %>
     <% task_presenter.sub_tasks.each do |sub_task| %>
         <div class="subtask ps-3 pe-3 pb-2">
           <div class="d-flex align-items-center gap-3 task-box">
-            <div class="d-flex justify-content-between align-items-center gap-3 task-description">
-
-              <%= render partial: "tasks/change_task_status_btn", locals: { task_presenter: sub_task } %>
-
-              <h5 class="m-0 fw-light fs-6 <%= sub_task.done? ? "line-through" : ""%>"><%= sub_task.description %></h5>
-              <span class="<%= sub_task.status_class_badge %>"><%= sub_task.status_translated %></span>
-            </div>
-            <div class="actions d-flex align-items-center gap-4">
-              <%= link_to edit_task_path(id: sub_task.task_id, parent_id: sub_task.parent_id), class: "text-secondary" do %>
-                <i class="bi bi-pencil-fill fs-6"></i>
-              <% end %>
-              <%= link_to task_path(sub_task.task_id), method: :delete, class: "text-danger fw-bold",
-                data: { confirm: "Tem certeza que deseja deletar?" } do %>
-                <i class="bi bi-x-lg fs-6"></i>
-              <% end %>
-            </div>
+            <%= render partial: 'tasks/task_content', locals: { task_presenter: sub_task } %>
           </div>
         </div>
     <% end %>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -17,23 +17,6 @@
     <%= link_to 'Voltar', tasks_path, class: "btn btn-primary" %>
   </header>
   <hr class="mt-2">
+  <%= render partial: "tasks/form", locals: { path: task_path, method: :put } %>
 
-  <%= form_with url: task_path, local: true, method: :put do |form| %>
-    <%= form.hidden_field :parent_id, value: @parent_id %>
-    <div class="row">
-      <div class="col-auto">
-        <%= form.label "Titulo", for: :description, class: "form-label" %>
-        <%= form.text_field :description, value: @task.description, placeholder: "Buscar crianças na escola",  class: "form-control" %>
-      </div>
-      <div class="col-auto">
-        <%= form.label "Data da tarefa", for: :date, class: "form-label" %>
-        <%= form.datetime_field :date, value: @time_value, class: "form-control"%>
-      </div>
-    </div>
-    <div class="row mt-3">
-      <div class="col-auto">
-        <%= form.submit "Salvar", class: "form-control btn btn-primary"%>
-      </div>
-    </div>
-  <% end %>
 </main>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -15,28 +15,18 @@
   </header>
   <hr class="mt-2">
 
-  <section class="day-section">
-    <h5 class="title m-0">Hoje</h5>
-    <section class="tasks-box p-3">
-      <% if @tasks_today_presenters.empty? %>
-        <h6 class="text-black-50 fw-normal">Nenhuma tarefa prevista</h6>
-      <% else %>
-        <% @tasks_today_presenters.each do |task_presenter| %>
-          <%= render partial: "tasks/task_wrapper", locals: { task_presenter: task_presenter } %>
+  <% @show_tasks_days.each do |tasks_day| %>
+    <section class="day-section">
+      <h5 class="title m-0"><%= tasks_day[:label_day] %></h5>
+      <section class="tasks-box p-3">
+        <% if tasks_day[:tasks_presenters].empty? %>
+          <h6 class="text-black-50 fw-normal">Nenhuma tarefa prevista</h6>
+        <% else %>
+          <% tasks_day[:tasks_presenters].each do |task_presenter| %>
+            <%= render partial: "tasks/task_wrapper", locals: { task_presenter: task_presenter } %>
+          <% end %>
         <% end %>
-      <% end %>
+      </section>
     </section>
-  </section>
-  <section class="day-section">
-    <h5 class="title m-0">Amanhã</h5>
-    <section class="tasks-box p-3">
-      <% if @tasks_tomorrow_presenters.empty? %>
-        <h6 class="text-black-50 fw-normal">Nenhuma tarefa prevista</h6>
-      <% else %>
-        <% @tasks_tomorrow_presenters.each do |task_presenter| %>
-          <%= render partial: "tasks/task_wrapper", locals: { task_presenter: task_presenter } %>
-        <% end %>
-      <% end %>
-    </section>
-  </section>
+  <% end %>
 </main>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -18,22 +18,5 @@
   </header>
   <hr class="mt-2">
 
-  <%= form_with url: tasks_path, local: true do |form| %>
-    <%= form.hidden_field :parent_id, value: @parent_id %>
-    <div class="row">
-      <div class="col-auto">
-        <%= form.label "Titulo", for: :description, class: "form-label" %>
-        <%= form.text_field :description, placeholder: "Buscar crianças na escola",  class: "form-control", required: true %>
-      </div>
-      <div class="col-auto">
-        <%= form.label "Data da tarefa", for: :date, class: "form-label" %>
-        <%= form.datetime_field :date, class: "form-control"%>
-      </div>
-    </div>
-    <div class="row mt-3">
-      <div class="col-auto">
-        <%= form.submit "Criar", class: "form-control btn btn-primary"%>
-      </div>
-    </div>
-  <% end %>
+  <%= render partial: "tasks/form", locals: { path: tasks_path, method: :post } %>
 </main>


### PR DESCRIPTION
# Objetivo

Com o intuito de deixar o código melhor entendível e mais reutilizável, se faz necessário a refatoração do código das views.

Este PR refatora das views de new e edit, criando um formulário genérico para ambos.

## Check list
- [x] Unificar form `new` e `edit`

## PRs relacionados
[[Fix] - Refatorando código da view index](https://github.com/SantosDiv/todo-list-rails/pull/27)

## Issues Actions
