### PR TITLE
[Fix] - Mudar status das subtasks conforme a mudança de status da task pai

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -60,9 +60,9 @@ class TasksController < ApplicationController
 
       @task.update(done: !old_status)
 
-      if @task.sub_task?
-        change_parent_status(parent: @task.parent)
-      end
+      @task.change_all_subtasks_status_by_parent! if @task.parent?
+
+      change_parent_status(parent: @task.parent) if @task.sub_task?
 
       redirect_to tasks_path
     rescue => exception

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -35,4 +35,11 @@ class Task < ApplicationRecord
 
     self.update(done: status)
   end
+
+  def change_all_subtasks_status_by_parent!
+    return unless self.done || self.parent?
+
+    parent_task_new_status = self.done
+    self.sub_tasks.each { |subtask| subtask.update(done: parent_task_new_status) }
+  end
 end

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -129,6 +129,27 @@ RSpec.describe TasksController, type: :controller do
         task.reload
         expect(task.done).to eq(true)
       end
+
+      context 'and has a subtasks' do
+        let(:parent_task) { create(:task, :with_two_sub_tasks) }
+
+        let(:params) {
+          {
+            task_id: parent_task.id
+          }
+        }
+
+        it 'change parent status and all subtasks status' do
+          put :change_status, params: params
+
+          parent_task.reload
+          subtasks = parent_task.sub_tasks
+
+          expect(parent_task.done).to eq(true)
+          expect(subtasks.first.done).to eq(parent_task.done)
+          expect(subtasks.second.done).to eq(parent_task.done)
+        end
+      end
     end
 
     context 'when is subtasks' do

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe TasksController, type: :controller do
         expect(task.done).to eq(true)
       end
 
-      context 'and has a subtasks' do
+      context 'and has subtasks' do
         let(:parent_task) { create(:task, :with_two_sub_tasks) }
 
         let(:params) {


### PR DESCRIPTION
# Objetivo
Foi visto que é um melhor cenário mudar o status de todas as subtasks quando uma task pai muda seu status. Ou seja, caso seja finalizada, finalizar todas as subtasks e vice-versa. 

Este PR entrega esta solução;

# Check list
- [x] Deve ser possível finalizar uma task pai e mudar o status das suas subtasks;
- [x] Testes