### PR TITLE
[Fix] - Removendo opção de criar uma subtask com data

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -23,7 +23,7 @@ class TasksController < ApplicationController
     rescue TaskException => exception
       redirect_to get_redirect_path(action: :new), danger: exception.message
     rescue
-      redirect_to new_task_path, danger: "Ocorreu um erro inesperado."
+      redirect_to tasks_path, danger: "Ocorreu um erro inesperado."
     end
   end
 
@@ -42,11 +42,11 @@ class TasksController < ApplicationController
 
   def destroy
     begin
+      @task.destroy!
+
       if @task.sub_task?
         change_parent_status(parent: @task.parent)
       end
-
-      @task.destroy!
 
       redirect_to tasks_path, success: "Tarefa deletada com sucesso"
     rescue

--- a/app/javascript/src/application.css
+++ b/app/javascript/src/application.css
@@ -94,6 +94,12 @@ body {
   gap: 15px;
 }
 
+.time {
+  font-size: 13px;
+  text-decoration: none!important;
+  margin-top: 4px;
+}
+
 @media (max-width: 720px) {
   .badge {
     display: none;

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,7 +3,7 @@ class Task < ApplicationRecord
   validates :done, inclusion: [true, false]
 
   belongs_to :parent, class_name: 'Task', optional: true
-  has_many :sub_tasks, -> { order("date") }, class_name: 'Task', foreign_key: :parent_id, dependent: :destroy
+  has_many :sub_tasks, -> { order("created_at") }, class_name: 'Task', foreign_key: :parent_id, dependent: :destroy
 
   scope :only_parent, -> { where(parent_id: nil) }
 

--- a/app/presenter/task_presenter.rb
+++ b/app/presenter/task_presenter.rb
@@ -54,4 +54,8 @@ class TaskPresenter
     @task.sub_tasks.map { |sub_task| TaskPresenter.new(task: sub_task) }
   end
 
+  def time
+    @task.date.strftime("%H:%Mhs")
+  end
+
 end

--- a/app/use_cases/create_task.rb
+++ b/app/use_cases/create_task.rb
@@ -1,11 +1,18 @@
 class CreateTask < TasksManager
   def execute
+    set_parent_date_in_params if subtask?
+
     task = Task.create(@task_params)
     update_parent_status(parent: task.parent) if subtask?
     task
   end
 
   private
+
+  def set_parent_date_in_params
+    parent_task = Task.find_by(id: @task_params[:parent_id])
+    @task_params[:date] = parent_task.date
+  end
 
   def update_parent_status(parent:)
     parent.change_parent_status!

--- a/app/use_cases/tasks_manager.rb
+++ b/app/use_cases/tasks_manager.rb
@@ -29,6 +29,8 @@ class TasksManager
   end
 
   def validate_datetime_subtask!
+    return true if @task_params[:date].nil?
+
     parent_task = Task.find(@task_params[:parent_id])
 
     if parent_task.date.to_date != @task_params[:date].to_date

--- a/app/use_cases/update_task.rb
+++ b/app/use_cases/update_task.rb
@@ -16,12 +16,10 @@ class UpdateTask < TasksManager
 
     subtasks = parent_task_updated.sub_tasks
 
-    date_parent_task = parent_task_updated.date.to_date
+    date_parent_task = parent_task_updated.date
 
     subtasks.each do |subtask|
-      original_time = subtask.date.strftime("%H:%M")
-
-      subtask.update(date: "#{date_parent_task} #{original_time}")
+      subtask.update(date: date_parent_task)
     end
   end
 

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -6,10 +6,12 @@
       <%= form.label "Titulo", for: :description, class: "form-label" %>
       <%= form.text_field :description, value: @task&.description, placeholder: "Buscar crianças na escola",  class: "form-control", required: true %>
     </div>
-    <div class="col-auto">
-      <%= form.label "Data da tarefa", for: :date, class: "form-label" %>
-      <%= form.datetime_field :date, value: @time_value, class: "form-control"%>
-    </div>
+    <% if @parent_id.nil? %>
+      <div class="col-auto">
+        <%= form.label "Data da tarefa", for: :date, class: "form-label" %>
+        <%= form.datetime_field :date, value: @time_value, class: "form-control"%>
+      </div>
+    <% end %>
   </div>
   <div class="row mt-3">
     <div class="col-auto">

--- a/app/views/tasks/_task_content.html.erb
+++ b/app/views/tasks/_task_content.html.erb
@@ -2,9 +2,14 @@
 
   <%= render partial: "tasks/change_task_status_btn", locals: { task_presenter: task_presenter } %>
 
-  <h5 class="m-0 <%= task_presenter.description_class %>"%>
-    <%= task_presenter.description %>
-  </h5>
+  <div class="d-flex align-items-center gap-2">
+    <h5 class="m-0 <%= task_presenter.description_class %>"%>
+      <%= task_presenter.description %>
+    </h5>
+    <% if task_presenter.parent? %>
+      <span class="time text-secondary"><%= task_presenter.time %></span>
+    <% end %>
+  </div>
   <span class="badge <%= task_presenter.status_class_badge %>"><%= task_presenter.status_translated %></span>
 </div>
 <div class="actions d-flex align-items-center">

--- a/spec/use_cases/create_task_spec.rb
+++ b/spec/use_cases/create_task_spec.rb
@@ -44,8 +44,8 @@ describe CreateTask do
 
         let(:params) {
           {
+            description: "New subtask",
             parent_id: parent_task.id,
-            **valid_task_params
           }
         }
 
@@ -54,6 +54,7 @@ describe CreateTask do
 
           expect(task.description).to eq(params[:description])
           expect(task.parent_id).to eq(parent_task.id)
+          expect(task.date.to_date).to eq(parent_task.date.to_date)
           expect(Task.count).to eq(2)
         end
 


### PR DESCRIPTION
# Objetivo
Pensando no princípio que uma sub tarefa é diretamente ligada a uma tarefa principal, não se faz necessário que a mesma tenha data/hora selecionáveis pelo usuário. Sendo assim, é preciso remover a opção de data e hora da criação e edição de uma sub tarefa.

## Chack list
- [x] Remover o input date do form de criação/edição de subtasks
- [x] A subtask deve receber a mesma data da sua task pai
- [x] A ordenação das subtask deve ser feita pelo created_at
- [x] Deve exibir o horário da task

## PRs Relacionados
[[Topic] - Adicionando horário ao lado do título da task](https://github.com/SantosDiv/todo-list-rails/pull/37)

## Issues Actions
#33  Closes