### PR TITLE
[Bugfix] - Corrigindo layout da box de tasks

### DIFF
--- a/app/javascript/src/application.css
+++ b/app/javascript/src/application.css
@@ -27,7 +27,7 @@ body {
   padding: 2em;
   width: 1150px;
   border-radius: 10px;
-  /* min-width: 360px; */
+  min-width: 360px;
 }
 
 .header-task {
@@ -49,7 +49,8 @@ body {
 .days-sections-container {
   max-height: 600px;
   overflow: scroll;
-  overflow-x: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .days-sections-container::-webkit-scrollbar {
@@ -141,8 +142,16 @@ body {
 }
 
 @media (max-width: 720px) {
+  .tasks-container {
+    margin: 1em;
+  }
+
+  .task-container {
+    gap: 20px;
+  }
+
   .description {
-    max-width: 200px!important;
+    max-width: 180px!important;
   }
 
   .badge {

--- a/app/javascript/src/application.css
+++ b/app/javascript/src/application.css
@@ -25,9 +25,9 @@ body {
   box-sizing: border-box;
   box-shadow: 0 1px 5px 0 rgba(0, 0, 0, 0.2);
   padding: 2em;
-  width: 60%;
+  width: 1150px;
   border-radius: 10px;
-  min-width: 360px;
+  /* min-width: 360px; */
 }
 
 .header-task {
@@ -44,6 +44,46 @@ body {
 .title {
   line-height: 1.1;
   color: var(--gray-500);
+}
+
+.days-sections-container {
+  max-height: 600px;
+  overflow: scroll;
+  overflow-x: auto;
+}
+
+.days-sections-container::-webkit-scrollbar {
+  width: 6px;
+}
+
+/* Track */
+.days-sections-container::-webkit-scrollbar-track {
+  background: transparent;
+  border-radius: 5px;
+}
+
+/* Handle */
+.days-sections-container::-webkit-scrollbar-thumb {
+  background: rgb(191, 191, 191);
+  border-radius: 5px;
+}
+
+/* Handle on hover */
+.days-sections-container::-webkit-scrollbar-thumb:hover {
+  background: #555;
+}
+
+.task-container {
+  flex-wrap: wrap;
+  transition: 1s;
+}
+
+.description {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 400px!important;
+  transition: 0.3s;
 }
 
 .btn-change-status {
@@ -101,6 +141,10 @@ body {
 }
 
 @media (max-width: 720px) {
+  .description {
+    max-width: 200px!important;
+  }
+
   .badge {
     display: none;
   }

--- a/app/views/tasks/_task_content.html.erb
+++ b/app/views/tasks/_task_content.html.erb
@@ -3,7 +3,7 @@
   <%= render partial: "tasks/change_task_status_btn", locals: { task_presenter: task_presenter } %>
 
   <div class="d-flex align-items-center gap-2">
-    <h5 class="m-0 <%= task_presenter.description_class %>"%>
+    <h5 class="m-0 description <%= task_presenter.description_class %>"%>
       <%= task_presenter.description %>
     </h5>
     <% if task_presenter.parent? %>

--- a/app/views/tasks/_task_content.html.erb
+++ b/app/views/tasks/_task_content.html.erb
@@ -3,7 +3,7 @@
   <%= render partial: "tasks/change_task_status_btn", locals: { task_presenter: task_presenter } %>
 
   <div class="d-flex align-items-center gap-2">
-    <h5 class="m-0 description <%= task_presenter.description_class %>"%>
+    <h5 class="m-0 description <%= task_presenter.description_class %>" title="<%= task_presenter.description %>">
       <%= task_presenter.description %>
     </h5>
     <% if task_presenter.parent? %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -15,18 +15,20 @@
   </header>
   <hr class="mt-2">
 
-  <% @show_tasks_days.each do |tasks_day| %>
-    <section class="day-section">
-      <h5 class="title m-0"><%= tasks_day[:label_day] %></h5>
-      <section class="tasks-box p-3">
-        <% if tasks_day[:tasks_presenters].empty? %>
-          <h6 class="text-black-50 fw-normal">Nenhuma tarefa prevista</h6>
-        <% else %>
-          <% tasks_day[:tasks_presenters].each do |task_presenter| %>
-            <%= render partial: "tasks/task_wrapper", locals: { task_presenter: task_presenter } %>
-          <% end %>
-        <% end %>
-      </section>
-    </section>
-  <% end %>
+  <main class="days-sections-container">
+    <% @show_tasks_days.each do |tasks_day| %>
+        <section class="day-section">
+          <h5 class="title m-0"><%= tasks_day[:label_day] %></h5>
+          <section class="tasks-box p-3">
+            <% if tasks_day[:tasks_presenters].empty? %>
+              <h6 class="text-black-50 fw-normal">Nenhuma tarefa prevista</h6>
+            <% else %>
+              <% tasks_day[:tasks_presenters].each do |task_presenter| %>
+                <%= render partial: "tasks/task_wrapper", locals: { task_presenter: task_presenter } %>
+              <% end %>
+            <% end %>
+          </section>
+        </section>
+    <% end %>
+  </main>
 </main>


### PR DESCRIPTION
# Objetivo
Durante os testes foi verificado que o layout está 'quebrando' quando o nome da task/subtask é grande e quando há muitas tasks.

Este PR entrega a correção desse bug visual.

- [x] É preciso fazer com que o nome da task, receba reticencias quando o nome for grande
- [x] É preciso que o box de task receba um scroll quando passar do tamanho ideal